### PR TITLE
Revert "glibc: fix do_populate_sdk fail when multilib used"

### DIFF
--- a/meta/recipes-core/glibc/glibc-package.inc
+++ b/meta/recipes-core/glibc/glibc-package.inc
@@ -153,7 +153,6 @@ do_install_armmultilib () {
 	oe_multilib_header bits/endian.h bits/fcntl.h bits/fenv.h bits/fp-fast.h bits/hwcap.h bits/ipc.h bits/link.h
 	oe_multilib_header bits/local_lim.h bits/mman.h bits/msq.h bits/pthreadtypes.h bits/pthreadtypes-arch.h  bits/sem.h  bits/semaphore.h bits/setjmp.h
 	oe_multilib_header bits/shm.h bits/sigstack.h bits/stat.h bits/statfs.h bits/typesizes.h
-	oe_multilib_header bits/procfs-id.h bits/procfs.h bits/shmlba.h
 
 	oe_multilib_header fpu_control.h gnu/lib-names.h gnu/stubs.h ieee754.h
 


### PR DESCRIPTION
This reverts commit bc853f87567bf977ab56e95aaa922fe194fdf990 because `bits/procfs.h`, `bits/procfs-id.h` and `bits/shmlba.h` are not available in the glibc 2.27.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>